### PR TITLE
Drag and Drop: Fixed drag source with ImGuiDragDropFlags_SourceAllowN…

### DIFF
--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -75,6 +75,8 @@ Other Changes:
 - Separator: Declare its thickness (1.0f) to the layout, making items around separator more symmetrical.
 - Combo, Slider, Scrollbar: Improve rendering in situation when there's only a few pixels available (<3 pixels).
 - Nav: Fixed Drag/Slider functions going into text input mode when keyboard CTRL is held while pressing NavActivate.
+- Drag and Drop: Fixed drag source with ImGuiDragDropFlags_SourceAllowNullID and null ID from receiving click
+  regardless of being covered by another window (it didn't honor correct hovering rules). (#2521)
 - ImDrawList: Improved algorithm for mitre joints on thick lines, preserving correct thickness up to 90 degrees
   angles, also faster to output. (#2518) [@rmitton]
 - Misc: Added IM_MALLOC/IM_FREE macros mimicking IM_NEW/IM_DELETE so user doesn't need to revert

--- a/docs/TODO.txt
+++ b/docs/TODO.txt
@@ -235,6 +235,7 @@ It's mostly a bunch of personal notes, probably incomplete. Feel free to query i
  - filters: handle wild-cards (with implicit leading/trailing *), reg-exprs
  - filters: fuzzy matches (may use code at blog.forrestthewoods.com/4cffeed33fdb)
 
+ - drag and drop: drag tooltip hovering over source widget with IsItemHovered/SetTooltip flickers.
  - drag and drop: releasing a drop shows the "..." tooltip for one frame - since e13e598 (#1725)
  - drag and drop: have some way to know when a drag begin from BeginDragDropSource() pov.
  - drag and drop: allow preview tooltip to be submitted from a different place than the drag source. (#1725)

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -8764,16 +8764,16 @@ bool ImGui::BeginDragDropSource(ImGuiDragDropFlags flags)
                 return false;
             }
 
+            // Early out
+            if ((window->DC.LastItemStatusFlags & ImGuiItemStatusFlags_HoveredRect) == 0 && (g.ActiveId == 0 || g.ActiveIdWindow != window))
+                return false;
+
             // Magic fallback (=somehow reprehensible) to handle items with no assigned ID, e.g. Text(), Image()
             // We build a throwaway ID based on current ID stack + relative AABB of items in window.
             // THE IDENTIFIER WON'T SURVIVE ANY REPOSITIONING OF THE WIDGET, so if your widget moves your dragging operation will be canceled.
             // We don't need to maintain/call ClearActiveID() as releasing the button will early out this function and trigger !ActiveIdIsAlive.
-            bool is_hovered = (window->DC.LastItemStatusFlags & ImGuiItemStatusFlags_HoveredRect) != 0;
-            if (!is_hovered && (g.ActiveId == 0 || g.ActiveIdWindow != window))
-                return false;
             source_id = window->DC.LastItemId = window->GetIDFromRectangle(window->DC.LastItemRect);
-            if (is_hovered)
-                SetHoveredID(source_id);
+            bool is_hovered = ItemHoverable(window->DC.LastItemRect, source_id);
             if (is_hovered && g.IO.MouseClicked[mouse_button])
             {
                 SetActiveID(source_id, window);


### PR DESCRIPTION
…ullID and null ID from receiving click regardless of being covered by another window (it didn't honor correct hovering rules). (#2521)

(Click "Preview" to turn any http URL into a clickable link)

PLEASE CAREFULLY READ:
https://github.com/ocornut/imgui/issues/2261

(Clear this template before submitting your PR)
